### PR TITLE
refactor(mcp): update validation logic to use mcpServers

### DIFF
--- a/packages/plugin-mcp/__test__/call_mcp.test.ts
+++ b/packages/plugin-mcp/__test__/call_mcp.test.ts
@@ -14,6 +14,12 @@ describe("mcpAction", () => {
                 tool1: {},
                 tool2: {},
             },
+            character: {
+                mcpServers: {
+                    tool1: {},
+                    tool2: {},
+                },
+            },
         } as any;
 
         const result = await mcpAction.validate(runtime, null as any);
@@ -22,7 +28,9 @@ describe("mcpAction", () => {
 
     it("should return false if mcpTools are not available in runtime", async () => {
         const runtime = {
-            mcpTools: {},
+            character: {
+                mcpServers: {},
+            },
         } as any;
 
         const result = await mcpAction.validate(runtime, null as any);

--- a/packages/plugin-mcp/src/actions/call_mcp.ts
+++ b/packages/plugin-mcp/src/actions/call_mcp.ts
@@ -20,7 +20,7 @@ export const mcpAction: Action = {
     examples: [],
     similes: [],
     validate: async (runtime: IAgentRuntime) => {
-        return Object.keys(runtime.mcpTools).length > 0;
+        return Object.keys(runtime.character.mcpServers).length > 0;
     },
     handler: async (
         runtime: IAgentRuntime,


### PR DESCRIPTION
## What does this PR do?
- Modified the `validate` method in `mcpAction` to check for the presence of `mcpServers` in the `character` object instead of `mcpTools`.
- Updated related tests to reflect the new structure, ensuring accurate validation of MCP server availability.

## What kind of change is this?

- [ ] feat: (new feature)
- [x] fix: (bug fix)
- [ ] chore: (updates to dependencies or build processes)
- [ ] docs: (documentation changes)
- [ ] style: (formatting, missing semi colons, etc; no code change)
- [ ] refactor: (refactoring production code)
- [ ] test: (adding tests, refactoring tests; no production code change)
- [ ] perf: (performance improvements)
